### PR TITLE
Zeromq6beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Coinos is a bitcoin wallet app that supports payments over the <a href="https://
 
 This repository contains the code for the backend API server which is implemented as a NodeJS application. The code for the frontend UI is tracked separately <a href="https://github.com/asoltys/coinos.io">here</a> (but is automatically installed & started via the Docker way outlined below). 
 
-## Install/Run (the Docker way)*
+## Install/Run (the Docker way)
 
 ### Requirements 
 
@@ -38,17 +38,6 @@ To shutdown coinos and all of its containers/services, run `docker-compose down`
 At anypoint to purge the database and start with a new one run `rm -rf mysql` and then `mkdir mysql` and then the same steps following from that point as outlined above. 
 
 To review a log of individual containers use `docker-compose app` or `docker-compose maria` etc; container names are available in `docker-compose.yml` or via `docker-compose ps` when they are running.  `docker images` will show you a list of the images installed on your system and `docker image rm [IMAGE ID]` removes them.
-
-*Known issue: coinos-server app container may currently crash in non production environment, to work around this you may edit `package.json` and edit the following line
-
-    "start" : "nodemon index.js", 
-    # change to: 
-    "start" : "SCOPE=MIN nodemon index.js",
-
-and then restart the container ie- `docker-compose restart app`
-
-Note this workaround disables most functionality including Bitcoin, Lightning, and Liquid interactions. 
-
 
 #### Volumes and local filesystem changes
 

--- a/routes/bitcoin/receive.js
+++ b/routes/bitcoin/receive.js
@@ -1,5 +1,5 @@
 const reverse = require("buffer-reverse");
-const zmq = require("zeromq");
+const zmq = require("zeromq/v5-compat");
 const { Op } = require("sequelize");
 const { fromBase58 } = require("bip32");
 

--- a/routes/liquid/receive.js
+++ b/routes/liquid/receive.js
@@ -1,6 +1,6 @@
 const axios = require("axios");
 const reverse = require("buffer-reverse");
-const zmq = require("zeromq");
+const zmq = require("zeromq/v5-compat");
 const { Op } = require("sequelize");
 const { fromBase58 } = require("bip32");
 const bitcoin = require("bitcoinjs-lib");


### PR DESCRIPTION
This increments zeromq to v6-beta (using v5 compat layer so no changes required) resolving an issue (affecting every Ubuntu 20 based system/docker/Github cloud instance I have deployed on) where the coinos-server node app crashes silently on start. 

https://github.com/zeromq/zeromq.js

Merge with care however since I don't quite yet have a satisfactory QA testing routine setup; I am not yet equipped to experiment with all features of Coinos to ensure this doesn't break anything else - but seems to at least run smooth/no errors from initial testing.  

Also updates README to remove the 'known limitation' which is resolved apart of said zeromq v6 update. 