### PR TITLE
delete "pending" field from getAccount call

### DIFF
--- a/routes/liquid/receive.js
+++ b/routes/liquid/receive.js
@@ -151,7 +151,7 @@ zmqRawTx.on("message", async (topic, message, sequence) => {
                   user_id: user.id,
                   asset,
                   pubkey: account.pubkey,
-                  pending: value,
+                  //pending: value,
                   index: 0
                 },
                 transaction


### PR DESCRIPTION
### Problem:
coinos-server makes redundant (more than one) accounts for one asset.
I think the problem might be in getAccount call, where the server is told to search for an account with a pending value. For this reason the server can't find the original account and thus makes a new one.
I'm not absolutely sure my diagnosis is correct. This is for admins to look.
### Solution:
Omit the "pending" from getAccount params.