### PR TITLE
fix: return invoice in nwc lookup_invoice by payment hash

### DIFF
--- a/lib/nwc.ts
+++ b/lib/nwc.ts
@@ -225,12 +225,13 @@ const handle = (method, params, user, ev) =>
           description,
           expires_at,
           preimage,
+          bolt11,
           paid_at: settled_at,
         } = invoices[0];
 
         return result({
           type: "incoming",
-          invoice,
+          invoice: bolt11,
           description,
           preimage,
           payment_hash,


### PR DESCRIPTION
UNTESTED

This returns the correct invoice in the response when requested by payment hash rather than invoice.

See https://github.com/nostr-protocol/nips/blob/master/47.md#lookup_invoice

(which says the invoice field in the response is optional, but the same field in the make_invoice response also says optional - which is definitely wrong).

EDIT: it also looks like the preimage is missing