### PR TITLE
Fix incorrect extratlvs format in pay_keysend

### DIFF
--- a/lib/nwc.ts
+++ b/lib/nwc.ts
@@ -249,8 +249,18 @@ const handle = (method, params, ev, app, user) =>
     },
 
     async pay_keysend() {
-      const { amount: amount_msat, pubkey, tlv_records: extratlvs } = params;
+      const { amount: amount_msat, pubkey, tlv_records } = params;
       const amount = Math.round(amount_msat / 1000);
+      const extratlvs = {};
+
+      // convert tlv_records to the extratlvs format
+      // tlv_records: [{ type: 1, value: "asdf" }]
+      // extratlvs: { "1": "asdf" }
+      if (tlv_records && tlv_records.length) {
+        for (const record of tlv_records) {
+          extratlvs[record.type.toString()] = record.value;
+        }
+      }
 
       try {
         const { payment_hash } = await sendKeysend({


### PR DESCRIPTION
The NWC `pay_keysend` format passes the `tlv_records` as an array of objects,
e.g. [ { "type": 5482373484, "value": "0123456789abcdef" } ]

But Core Lightning expects the `extratlvs` field to be in key/value format,
e.g. { "5482373484": "0123456789abcdef" }

This PR adds code to convert from one format to the other.

References:
https://github.com/nostr-protocol/nips/blob/master/47.md#pay_keysend
https://docs.corelightning.org/reference/keysend#description