### PR TITLE
Catch failed keysend payments

### DIFF
--- a/lib/payments.ts
+++ b/lib/payments.ts
@@ -505,17 +505,18 @@ export const sendKeysend = async ({
     type: PaymentType.lightning,
   });
 
-  const r = await ln.keysend({
-    destination: pubkey,
-    amount_msat: amount * 1000,
-    maxfee: fee * 1000,
-    retry_for: 10,
-    extratlvs,
-  });
-
-  if (r.status !== "complete") reverse(p);
-
-  return r;
+  try {
+    return await ln.keysend({
+      destination: pubkey,
+      amount_msat: amount * 1000,
+      maxfee: fee * 1000,
+      retry_for: 10,
+      extratlvs,
+    });
+  } catch (e) {
+    reverse(p);
+    throw e;
+  }
 };
 
 export const sendLightning = async ({


### PR DESCRIPTION
The code currently doesn't catch exceptions when ln.keysend is called and doesn't reverse the charge when an exception happens. This adds a try catch block so that failed payments are reversed.

The code seems to rely on status = complete to determine if the payment went through, but this field is always set to complete according to the documentation: https://docs.corelightning.org/reference/keysend#return-value